### PR TITLE
Separated dev and prod Firestore instances

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,7 @@
+REACT_APP_API_KEY=AIzaSyDzdaoD1OvbyAmi5_3jvs8WMkXshzIp4go
+REACT_APP_AUTH_DOMAIN=safar-dev-3bfe1.firebaseio.com
+REACT_APP_DATABASE_URL=https://safar-dev-3bfe1.firebaseio.com
+REACT_APP_PROJECT_ID=safar-dev-3bfe1
+REACT_APP_STORAGE_BUCKET=safar-dev-3bfe1.appspot.com
+REACT_APP_MESSAGING_SENDER_ID=393013885137
+

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -142,12 +142,15 @@ class AdminPage extends Component {
   };
 
   componentDidMount() {
-    this.setState({ loadingLangs: true, loadingServices: true });
+    this.setState({ loadingLangs: false, loadingServices: false});
 
     this.unsubscribe = this.props.firebase.providers().onSnapshot(snapshot => {
       let providersList = [];
 
       let idx = 0;
+      if(snapshot.size === 0) {
+        this.setState({loadingLangs: false, loadingServices: false});
+      }
       snapshot.forEach(doc => {
         let names = [];
         let languages = [];
@@ -156,12 +159,14 @@ class AdminPage extends Component {
 
         let gotLangs = false,
           gotServices = false;
-
         this.props.firebase
           .provider(doc.id)
           .collection("languages")
           .get()
           .then(langSnapshot => {
+            if(langSnapshot.size === 0) {
+              this.setState({loadingLangs: false});
+            }
             langSnapshot.forEach(langDoc => {
               names.push(langDoc.data().orgName);
               languages.push({ language: langDoc.id, ...langDoc.data() });
@@ -200,7 +205,9 @@ class AdminPage extends Component {
             //   services.push(servDoc.id);
             // });
             services = servsSnapshot.size;
-
+            if(services === 0) {
+              this.setState({loadingServices: false});
+            }
             if (gotLangs) {
               providersList.push({
                 key: idx,


### PR DESCRIPTION
Modified Admin page to finish loading even if there are no providers /
services.

The deployed version will automatically use the prod db.